### PR TITLE
修复一些bug

### DIFF
--- a/src/main/kotlin/cf/wayzer/contentsTweaker/PatchHandler.kt
+++ b/src/main/kotlin/cf/wayzer/contentsTweaker/PatchHandler.kt
@@ -63,16 +63,16 @@ object PatchHandler {
             return "Node(key='$key')"
         }
 
-        interface WithObj {
-            val obj: Any?
-            val type: Class<*>?
+        interface WithObj<T> {
+            val obj: T
+            val type: Class<*>
             val elementType: Class<*>? get() = null
             val keyType: Class<*>? get() = null
         }
 
         //Node with obj, not Modifiable, use as simple node
-        class ObjNode(override val parent: Node, key: String, override val obj: Any, override val type: Class<out Any> = obj.javaClass) :
-            Node(key), WithObj
+        class ObjNode<T : Any>(override val parent: Node, key: String, override val obj: T, override val type: Class<T> = obj.javaClass) :
+            Node(key), WithObj<T>
 
         interface Storable {
             val storeDepth: Int
@@ -80,22 +80,11 @@ object PatchHandler {
             fun doRecover()
         }
 
-        interface Modifiable : WithObj, Storable {
-            //            /**
-//             * 可直接修改[obj]对象.通过其他机制可保证还原
-//             * true时: [doStore0]负责拷贝对象,并保存,由[recover]负责恢复
-//             * false时: 由[Modifier]负责产生新对象并[setValue]
-//             * */
-//            val mutableObj: Boolean get() = false
-            fun setValue(value: Any?)
-//            fun doStore() {
-//                if (mutableObj) error("mutable Modifiable need impl doStore0 to backup obj")
-//            }
-//
-//            fun recover() {
-//                if (mutableObj) error("mutable Modifiable need impl recover to recover obj")
-//                setValue(obj)
-//            }
+        interface Modifiable<T> : WithObj<T>, Storable {
+            fun setValue(value: T)
+
+            @Suppress("UNCHECKED_CAST")
+            fun setValueAny(value: Any?) = setValue(type.cast(value) as T)
         }
 
         fun interface Modifier {

--- a/src/main/kotlin/cf/wayzer/contentsTweaker/resolvers/BaseModifier.kt
+++ b/src/main/kotlin/cf/wayzer/contentsTweaker/resolvers/BaseModifier.kt
@@ -8,11 +8,11 @@ import cf.wayzer.contentsTweaker.TypeRegistry
 object BaseModifier : PatchHandler.Resolver {
     override fun resolve(node: Node, child: String): Node? {
         if (child != "=") return null
-        if (node !is Node.Modifiable) error("${node.key} is not Modifiable, can't assign")
+        if (node !is Node.Modifiable<*>) error("${node.key} is not Modifiable, can't assign")
         return node.withModifier(child) { json ->
             val value = TypeRegistry.resolveType(json, type, elementType, keyType)
             beforeModify()
-            setValue(value)
+            setValueAny(value)
         }
     }
 }

--- a/src/main/kotlin/cf/wayzer/contentsTweaker/resolvers/BlockConsumesResolver.kt
+++ b/src/main/kotlin/cf/wayzer/contentsTweaker/resolvers/BlockConsumesResolver.kt
@@ -11,55 +11,54 @@ import mindustry.world.consumers.*
 
 object BlockConsumesResolver : PatchHandler.Resolver, TypeRegistry.Resolver {
     override fun resolve(node: Node, child: String): Node? {
-        if (node is Node.Modifiable && node.obj is Array<*> && node.elementType == Consume::class.java) {
-            val block = ((node.parent as Node.WithObj).obj as? Block) ?: return null
-            fun modifier(body: Array<Consume>.(JsonValue) -> Array<Consume>) = node.withModifier(child) {
-                beforeModify()
-                PatchHandler.registerAfterHandler(node.key) {
-                    block.apply {
-                        consPower = consumers.filterIsInstance<ConsumePower>().firstOrNull()
-                        optionalConsumers = consumers.filter { it.optional && !it.ignore() }.toTypedArray()
-                        nonOptionalConsumers = consumers.filter { !it.optional && !it.ignore() }.toTypedArray()
-                        updateConsumers = consumers.filter { it.update && !it.ignore() }.toTypedArray()
-                        hasConsumers = consumers.isNotEmpty()
-                        itemFilter.fill(false)
-                        liquidFilter.fill(false)
-                        consumers.forEach { it.apply(this) }
-                        setBars()
-                    }
+        if (node !is Node.Modifiable<*> || !Array<Consume>::class.java.isAssignableFrom(node.type))
+            return null
+        val block = ((node.parent as Node.WithObj<*>).obj as? Block) ?: return null
+        fun modifier(body: Array<Consume>.(JsonValue) -> Array<Consume>) = node.withModifier(child) { v ->
+            beforeModify()
+            PatchHandler.registerAfterHandler(key) {
+                block.apply {
+                    consPower = consumers.filterIsInstance<ConsumePower>().firstOrNull()
+                    optionalConsumers = consumers.filter { it.optional && !it.ignore() }.toTypedArray()
+                    nonOptionalConsumers = consumers.filter { !it.optional && !it.ignore() }.toTypedArray()
+                    updateConsumers = consumers.filter { it.update && !it.ignore() }.toTypedArray()
+                    hasConsumers = consumers.isNotEmpty()
+                    itemFilter.fill(false)
+                    liquidFilter.fill(false)
+                    consumers.forEach { it.apply(this) }
+                    setBars()
                 }
-                @Suppress("UNCHECKED_CAST") val obj = node.obj as Array<Consume>
-                setValue(obj.body(it))
             }
-            return when (child) {
-                "clearItems" -> modifier { filterNot { it is ConsumeItems || it is ConsumeItemFilter }.toTypedArray() }
-                "item" -> modifier { this + ConsumeItems(arrayOf(ItemStack(TypeRegistry.resolve(it), 1))) }
-                "items" -> modifier { this + TypeRegistry.resolve<ConsumeItems>(it) }
-                "itemCharged" -> modifier { this + TypeRegistry.resolve<ConsumeItemCharged>(it) }
-                "itemFlammable" -> modifier { this + TypeRegistry.resolve<ConsumeItemFlammable>(it) }
-                "itemRadioactive" -> modifier { this + TypeRegistry.resolve<ConsumeItemRadioactive>(it) }
-                "itemExplosive" -> modifier { this + TypeRegistry.resolve<ConsumeItemExplosive>(it) }
-                "itemExplode" -> modifier { this + TypeRegistry.resolve<ConsumeItemExplode>(it) }
-
-                "clearLiquids" -> modifier { filterNot { it is ConsumeLiquidBase || it is ConsumeLiquids }.toTypedArray() }
-                "liquid" -> modifier { this + TypeRegistry.resolve<ConsumeLiquid>(it) }
-                "liquids" -> modifier { this + TypeRegistry.resolve<ConsumeLiquids>(it) }
-                "liquidFlammable" -> modifier { this + TypeRegistry.resolve<ConsumeLiquidFlammable>(it) }
-                "coolant" -> modifier { this + TypeRegistry.resolve<ConsumeCoolant>(it) }
-
-                "clearPower" -> modifier { filterNot { it is ConsumePower }.toTypedArray() }
-                "power" -> modifier {
-                    this.filterNot { c -> c is ConsumePower }.toTypedArray() + TypeRegistry.resolve<ConsumePower>(it)
-                }
-
-                "powerBuffered" -> modifier {
-                    this.filterNot { c -> c is ConsumePower }.toTypedArray() + ConsumePower(0f, it.asFloat(), true)
-                }
-
-                else -> null
-            }
+            @Suppress("UNCHECKED_CAST")
+            setValueAny((obj as Array<Consume>).body(v))
         }
-        return null
+        return when (child) {
+            "clearItems" -> modifier { filterNot { it is ConsumeItems || it is ConsumeItemFilter }.toTypedArray() }
+            "item" -> modifier { this + ConsumeItems(arrayOf(ItemStack(TypeRegistry.resolve(it), 1))) }
+            "items" -> modifier { this + TypeRegistry.resolve<ConsumeItems>(it) }
+            "itemCharged" -> modifier { this + TypeRegistry.resolve<ConsumeItemCharged>(it) }
+            "itemFlammable" -> modifier { this + TypeRegistry.resolve<ConsumeItemFlammable>(it) }
+            "itemRadioactive" -> modifier { this + TypeRegistry.resolve<ConsumeItemRadioactive>(it) }
+            "itemExplosive" -> modifier { this + TypeRegistry.resolve<ConsumeItemExplosive>(it) }
+            "itemExplode" -> modifier { this + TypeRegistry.resolve<ConsumeItemExplode>(it) }
+
+            "clearLiquids" -> modifier { filterNot { it is ConsumeLiquidBase || it is ConsumeLiquids }.toTypedArray() }
+            "liquid" -> modifier { this + TypeRegistry.resolve<ConsumeLiquid>(it) }
+            "liquids" -> modifier { this + TypeRegistry.resolve<ConsumeLiquids>(it) }
+            "liquidFlammable" -> modifier { this + TypeRegistry.resolve<ConsumeLiquidFlammable>(it) }
+            "coolant" -> modifier { this + TypeRegistry.resolve<ConsumeCoolant>(it) }
+
+            "clearPower" -> modifier { filterNot { it is ConsumePower }.toTypedArray() }
+            "power" -> modifier {
+                this.filterNot { c -> c is ConsumePower }.toTypedArray() + TypeRegistry.resolve<ConsumePower>(it)
+            }
+
+            "powerBuffered" -> modifier {
+                this.filterNot { c -> c is ConsumePower }.toTypedArray() + ConsumePower(0f, it.asFloat(), true)
+            }
+
+            else -> null
+        }
     }
 
     override fun <T : Any> resolveType(json: JsonValue, type: Class<T>?, elementType: Class<*>?, keyType: Class<*>?): T? {

--- a/src/main/kotlin/cf/wayzer/contentsTweaker/resolvers/ObjectMapItemNode.kt
+++ b/src/main/kotlin/cf/wayzer/contentsTweaker/resolvers/ObjectMapItemNode.kt
@@ -7,11 +7,11 @@ import cf.wayzer.contentsTweaker.PatchHandler.Node
 import cf.wayzer.contentsTweaker.PatchHandler.withModifier
 import cf.wayzer.contentsTweaker.TypeRegistry
 
-class ObjectMapItemNode(override val parent: Node, val mapKey: Any?, key: String) : Node(key), Node.Modifiable {
+class ObjectMapItemNode(override val parent: Node, val mapKey: Any?, key: String) : Node(key), Node.Modifiable<Any?> {
     @Suppress("UNCHECKED_CAST")
-    private val map = ((parent as WithObj).obj as ObjectMap<Any, Any>)
-    override val type: Class<*>?
-        get() = (parent as WithObj).elementType ?: obj?.javaClass
+    private val map = ((parent as WithObj<*>).obj as ObjectMap<Any, Any>)
+    override val type: Class<*>
+        get() = (parent as WithObj<*>).elementType ?: obj?.javaClass ?: Any::class.java
 
     override fun setValue(value: Any?) {
         map.put(mapKey, value)
@@ -36,7 +36,7 @@ class ObjectMapItemNode(override val parent: Node, val mapKey: Any?, key: String
 
     companion object Resolver : PatchHandler.Resolver {
         override fun resolve(node: Node, child: String): Node? {
-            if (node !is WithObj) return null
+            if (node !is WithObj<*>) return null
             val obj = node.obj
             if (obj !is ObjectMap<*, *>) return null
             val keyType = node.keyType ?: (obj.keys().firstOrNull()?.javaClass)

--- a/src/main/kotlin/cf/wayzer/contentsTweaker/resolvers/UIExtNode.kt
+++ b/src/main/kotlin/cf/wayzer/contentsTweaker/resolvers/UIExtNode.kt
@@ -168,8 +168,8 @@ open class UIExtNode(override val parent: PatchHandler.Node, key: String, val ui
     }
 
     companion object Resolver : PatchHandler.Resolver {
-        val alignMap = Align::class.java.declaredFields.associate { it.name to it.getInt(null) }
-        val stylesMap = Styles::class.java.declaredFields.associate { it.name to it.get(null)!! }
+        val alignMap by lazy { Align::class.java.declaredFields.associate { it.name to it.getInt(null) } }
+        val stylesMap by lazy { Styles::class.java.declaredFields.associate { it.name to it.get(null)!! } }
         fun createUIElement(type: String): Element = when (type) {
             "Table" -> Table()
             "Label" -> Label("")

--- a/src/main/kotlin/cf/wayzer/contentsTweaker/resolvers/UIExtNode.kt
+++ b/src/main/kotlin/cf/wayzer/contentsTweaker/resolvers/UIExtNode.kt
@@ -14,6 +14,7 @@ import arc.scene.ui.layout.Table
 import arc.util.Align
 import cf.wayzer.contentsTweaker.PatchHandler
 import cf.wayzer.contentsTweaker.PatchHandler.withModifier
+import mindustry.Vars
 import mindustry.gen.Call
 import mindustry.ui.Styles
 
@@ -157,7 +158,7 @@ open class UIExtNode(override val parent: PatchHandler.Node, key: String, val ui
         else -> null
     }
 
-    object Root : UIExtNode(PatchHandler.Node.Root, "uiExt.", Core.scene.root), Storable {
+    object Root : UIExtNode(PatchHandler.Node.Root, "uiExt.", Core.scene.root ?: Element()), Storable {
         override val storeDepth: Int = Int.MAX_VALUE
         override fun doSave() {}
         override fun doRecover() {
@@ -176,6 +177,7 @@ open class UIExtNode(override val parent: PatchHandler.Node, key: String, val ui
         }
 
         override fun resolve(node: PatchHandler.Node, child: String): PatchHandler.Node? {
+            if (Vars.headless) return null
             if (node == PatchHandler.Node.Root && child == "uiExt") return Root
             return null
         }

--- a/src/main/kotlin/cf/wayzer/contentsTweaker/resolvers/UIExtNode.kt
+++ b/src/main/kotlin/cf/wayzer/contentsTweaker/resolvers/UIExtNode.kt
@@ -51,7 +51,7 @@ import mindustry.ui.Styles
  * }
  * ```
  */
-open class UIExtNode(override val parent: PatchHandler.Node, key: String, val uiNode: Element) : PatchHandler.Node(key), PatchHandler.Node.WithObj {
+open class UIExtNode(override val parent: PatchHandler.Node, key: String, val uiNode: Element) : PatchHandler.Node(key), PatchHandler.Node.WithObj<Element> {
     private var tableCell: Cell<Element>? = null
     val children = mutableMapOf<String, UIExtNode>()
     override val obj get() = uiNode


### PR DESCRIPTION
* 修复comsumes仍然无法工作问题
* 修复`ReflectNode`返回obj过时问题
* 修复`UIExt`在服务端运行报错问题
### 附无中生有示例代码
```json5
{block.graphite-press.consumers:{clearItems:1,clearLiquids:1}
block.multi-press.consumers:{clearItems:1,clearLiquids:1}
block.silicon-smelter.consumers:{clearItems:1,clearLiquids:1}
block.silicon-crucible.consumers:{clearItems:1,clearLiquids:1}
block.kiln.consumers:{clearItems:1,clearLiquids:1}
block.plastanium-compressor.consumers:{clearItems:1,clearLiquids:1}
block.phase-weaver.consumers:{clearItems:1,clearLiquids:1}
block.surge-smelter.consumers:{clearItems:1,clearLiquids:1}
block.cryofluid-mixer.consumers:{clearItems:1,clearLiquids:1}
block.pyratite-mixer.consumers:{clearItems:1,clearLiquids:1}
block.blast-mixer.consumers:{clearItems:1,clearLiquids:1}
block.melter.consumers:{clearItems:1,clearLiquids:1}
block.separator.consumers:{clearItems:1,clearLiquids:1}
block.disassembler.consumers:{clearItems:1,clearLiquids:1}
block.spore-press.consumers:{clearItems:1,clearLiquids:1}
block.pulverizer.consumers:{clearItems:1,clearLiquids:1}
block.coal-centrifuge.consumers:{clearItems:1,clearLiquids:1}
block.silicon-arc-furnace.consumers:{clearItems:1,clearLiquids:1}
block.electrolyzer.consumers:{clearItems:1,clearLiquids:1}
block.atmospheric-concentrator.consumers:{clearItems:1,clearLiquids:1}
block.oxidation-chamber.consumers:{clearItems:1,clearLiquids:1}
block.electric-heater.consumers:{clearItems:1,clearLiquids:1}
block.slag-heater.consumers:{clearItems:1,clearLiquids:1}
block.phase-heater.consumers:{clearItems:1,clearLiquids:1}
block.carbide-crucible.consumers:{clearItems:1,clearLiquids:1}
block.slag-centrifuge.consumers:{clearItems:1,clearLiquids:1}
block.surge-crucible.consumers:{clearItems:1,clearLiquids:1}
block.cyanogen-synthesizer.consumers:{clearItems:1,clearLiquids:1}
block.phase-synthesizer.consumers:{clearItems:1,clearLiquids:1}
block.heat-reactor.consumers:{clearItems:1,clearLiquids:1}
block.cultivator.consumers:{clearItems:1,clearLiquids:1}
block.vent-condenser.consumers:{clearItems:1,clearLiquids:1}
block.heat-source.consumers:{clearItems:1,clearLiquids:1}}
```